### PR TITLE
ci: switch dependabot automerge to native GitHub auto-merge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,29 @@
+name: Automerge Dependabot
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Enable auto-merge for Dependabot PRs
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0].user.login == 'dependabot[bot]' &&
+      github.event.workflow_run.pull_requests[0].head.repo.full_name == github.repository
+    steps:
+      - name: Enable native auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.workflow_run.pull_requests[0].html_url }}
+        run: |
+          echo "Enabling auto-merge for $PR_URL"
+          gh pr merge --auto --squash --delete-branch "$PR_URL" \
+            || echo "::warning::Could not enable auto-merge (PR may already be merged or closed)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,21 +40,3 @@ jobs:
 
       - name: Validate rules
         run: pnpm validate
-
-  automerge:
-    name: Automerge Dependabot PRs
-    if: >
-        always() &&
-        needs.ci.result == 'success' &&
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.user.login == 'dependabot[bot]'
-    needs: [ci]
-    permissions:
-      pull-requests: write
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: fastify/github-action-merge-dependabot@1b2ed42db8f9d81a46bac83adedfc03eb5149dff # v3.11.2
-        with:
-          target: major


### PR DESCRIPTION
## Summary

Replace the third-party `fastify/github-action-merge-dependabot` action — whose underlying `@dependabot merge` command GitHub deprecated in January 2026 — with GitHub's native auto-merge API via `gh pr merge --auto`.

The previous setup was bundled inside `ci.yaml` as a second job. This PR splits it into its own `.github/workflows/automerge.yml` so each workflow file has a single responsibility and removes the third-party action dependency.

## Changes

- **`.github/workflows/automerge.yml`** (new): runs on `workflow_run` after `CI` completes; enables native auto-merge via `gh pr merge --auto --squash --delete-branch` for any successful-CI PR opened by `dependabot[bot]` against this repo.
- **`.github/workflows/ci.yaml`**: removes the inlined `automerge` job (now superseded by the new workflow).

## How it works

1. Dependabot opens a PR → `CI` workflow runs.
2. When `CI` completes successfully, GitHub fires the `workflow_run` event for the `automerge` workflow.
3. The `if` conditions check that the trigger was a pull_request, that CI succeeded, and that the PR was opened by `dependabot[bot]` against this repo (not a fork).
4. The job calls `gh pr merge --auto --squash --delete-branch` on the PR URL from the `workflow_run` event payload — this is GitHub's native auto-merge, equivalent to clicking the "Enable auto-merge" button in the UI.
5. Once any remaining branch-protection requirements are met, GitHub merges and deletes the dependabot branch automatically.

## Prerequisites

The repo must have **Settings → General → Pull Requests → "Allow auto-merge"** enabled. (This is the same prerequisite the previous setup had, since v3.10+ of the fastify action also uses the native API.)

## Why this is safer than the previous setup

- No third-party action runs in the repo's CI context.
- No reliance on a deprecated comment command — uses the GitHub-supported `gh pr merge --auto` API.
- Clear, readable conditions; no opaque action behaviour.
- Single-responsibility workflow file.

## Test plan

- [x] `actionlint` passes cleanly on both workflow files.
- [x] YAML schema validates for both files.
- [ ] Verify on first dependabot PR after merge: a successful `CI` run should trigger the `automerge` workflow, which should enable auto-merge on the PR.
- [ ] Confirm the auto-merged PR squash commit and deleted branch look correct in the history.

## Notes

- I considered restricting auto-merge to specific semver levels (e.g. patch+minor only) but kept the previous behaviour of merging all update types, since the current CI (lint + validate + `frozen-lockfile` install) reliably catches breakage for these devDependencies. Easy to add filtering later via the PR title prefix if needed.
- I did **not** add a changeset since this is purely CI infrastructure with no user-facing impact; happy to add one if preferred.