### PR TITLE
ci: trigger CI on pnpm workspace and lockfile changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,16 @@ on:
       - "skills/**/rules/**"
       - "packages/validate-rules/**"
       - "package.json"
+      - "pnpm-workspace.yaml"
+      - "pnpm-lock.yaml"
   pull_request:
     branches: [main]
     paths:
       - "skills/**/rules/**"
       - "packages/validate-rules/**"
       - "package.json"
+      - "pnpm-workspace.yaml"
+      - "pnpm-lock.yaml"
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary

Extend the CI workflow path filters so that changes to the pnpm workspace configuration or lockfile also trigger the lint and validate jobs.

## Changes

- `.github/workflows/ci.yaml`: add `pnpm-workspace.yaml` and `pnpm-lock.yaml` to the `paths` filters for both `push` and `pull_request` triggers.

## Motivation

Previously the CI workflow only ran when rules under `skills/**/rules/**`, the validate-rules package, or `package.json` changed. Updates to the pnpm workspace (e.g. adding a new package to the workspace or adjusting catalog versions) or to the lockfile could therefore go undetected by CI.