### PR TITLE
fix(release): include root package in pnpm workspace so changesets recognises @thecodepace/fastify-skills

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "type": "git",
     "url": "git+https://github.com/TheCodePace/fastify-skills.git"
   },
-  "workspaces": [
-    "packages/*"
-  ],
   "type": "module",
   "scripts": {
     "lint": "oxlint .",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
-  - packages/*
+  - "."
+  - "packages/*"
 
 catalog:
   "@changesets/cli": ^2.31.1


### PR DESCRIPTION
## Summary

Unblock the **Release workflow** by making changesets aware of the `@thecodepace/fastify-skills` root package — it has been silently broken since the Feb-2026 monorepo restructure.

## The problem

After merging #122 the Release workflow reached the `Create Release Pull Request` step (run [#29650533437](https://github.com/TheCodePace/fastify-skills/actions/runs/29650533437)) for the first time and immediately failed:

```
🦋  error  Error: Found changeset add-authentication-rule for
             package @thecodepace/fastify-skills which is not in the workspace
```

### Why it broke

In commit `9217f84` (2026-02-20, `feat(validate-rules): add validation tooling…`) the repo was restructured into a pnpm workspace. That created `packages/validate-rules` (`@thecodepace/validate-rules`) but the root `package.json` kept `name: @thecodepace/fastify-skills`. Since `pnpm-workspace.yaml` only listed `packages/*` as a workspace, the root package became invisible to changesets — even though all 22 legacy changesets (and the new `.changeset/bump-github-actions.md`) reference it.

The bug was latent because every prior release run died earlier on a different error (missing `pnpm` install step — fixed in #122). It surfaced the first time changesets was actually reached.

## The fix

Two small edits to put the root back in the workspace cleanly:

`pnpm-workspace.yaml`:
```diff
 packages:
-  - packages/*
+  - "."
+  - "packages/*"
```

`package.json` (root):
```diff
   "repository": { ... },
-  "workspaces": [
-    "packages/*"
-  ],
   "type": "module",
```

- Adding `.` to `pnpm-workspace.yaml` makes the root `package.json` a workspace member alongside `packages/*`.
- Removing `workspaces` from `package.json` is cleanup: in pnpm 10, `pnpm-workspace.yaml` is authoritative and the package.json form is deprecated.

## Verification

```
$ pnpm ls -r --depth=-1
@thecodepace/fastify-skills@0.1.0 /root/repos/fastify-skills
@thecodepace/validate-rules@1.0.0 /root/repos/fastify-skills/packages/validate-rules (PRIVATE)

$ pnpm exec changeset status
🦋  info Packages to be bumped at minor:
🦋  info - @thecodepace/fastify-skills
🦋  info - @thecodepace/validate-rules
```

All other checks pass on this branch: `pnpm lint`, `pnpm format:check`, `pnpm validate` (all 32 rules valid). `pnpm install --frozen-lockfile` runs without lockfile changes.

## Notes for the reviewer

- This PR does **not** include a changeset. The pending `.changeset/bump-github-actions.md` (from #122) plus the 22 legacy changesets already cover this fix as part of the upcoming release — adding another changeset on top would be double-counted.
- No further documentation change is needed. The published package layout, install instructions, and skill loading are all unchanged — only changesets' awareness of the root package.
- Once this merges, the next `workflow_dispatch` on the Release workflow should successfully open a release PR that bumps `@thecodepace/fastify-skills` to its first real published version.
